### PR TITLE
Fix 'docker run' command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ docker build -t alpine-lighttpd-php .
 
 Run using;
 
-docker run --name "my-lighttpd-php" -p 8000:80 -v $(pwd):/var/www docker pull alastairhm/alpine-lighttpd-php
+docker run --name "my-lighttpd-php" -p 8000:80 -v $(pwd):/var/www alastairhm/alpine-lighttpd-php
 
 Works for static & PHP web content.


### PR DESCRIPTION
Hey @alastairhm,

I've stumbled upon your repo and noticed the "docker run" command in your README.md doesn't work, so I'd like to contribute even if this repo is a bit older ;-)

Thank you for sharing! 👍 🚀 

It just helped me quickly debugging and fixing this issue:
https://github.com/nextcloud/desktop/issues/1473

Greetings,
Michael

```
Removes "docker pull" before "alastairhm/alpine-lighttpd-php" which caused
Docker to pull the "docker" container instead.
```